### PR TITLE
Update eslint and prettier config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,6 +24,10 @@ module.exports = {
   ].filter(Boolean),
   rules: {
     'unicorn/prefer-node-protocol': 'error',
+    '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {fixStyle: 'inline-type-imports', disallowTypeAnnotations: false},
+    ],
   },
   overrides: [
     {

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -6,6 +6,7 @@ module.exports = {
   ],
   singleQuote: true,
   htmlWhitespaceSensitivity: 'ignore',
+  endOfLine: "auto",
   overrides: [
     {
       files: '*.astro',

--- a/packages/actions-new-meetup/src/index.ts
+++ b/packages/actions-new-meetup/src/index.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import { context, getOctokit } from '@actions/github';
 import format from 'date-fns/format';
 import {
-  Steps,
+  type Steps,
   getMeetupIssueCommentStatus,
   getMeetupMarkdownFileContent,
   getMeetupPullRequestContent,

--- a/packages/api/src/workerCreateIssue.ts
+++ b/packages/api/src/workerCreateIssue.ts
@@ -1,7 +1,7 @@
-import { getMeetupIssueBody, meetupSchema, Meetup } from 'meetup-shared';
+import { getMeetupIssueBody, meetupSchema, type Meetup } from 'meetup-shared';
 import { App } from 'octokit';
 import { safeParseAsync } from 'valibot';
-import { Env } from './workerEnv';
+import { type Env } from './workerEnv';
 
 export async function parseCreateIssueReqBody(
   req: Request,

--- a/packages/api/src/workerHandler.ts
+++ b/packages/api/src/workerHandler.ts
@@ -1,5 +1,5 @@
 import { createIssue, parseCreateIssueReqBody } from './workerCreateIssue';
-import { Env } from './workerEnv';
+import { type Env } from './workerEnv';
 
 export async function handleRequest(req: Request, env: Env): Promise<Response> {
   const meetupParseResult = await parseCreateIssueReqBody(req);

--- a/packages/meetup-shared/src/formatValidationErrors.ts
+++ b/packages/meetup-shared/src/formatValidationErrors.ts
@@ -1,4 +1,4 @@
-import { Issues } from 'valibot';
+import { type Issues } from 'valibot';
 
 export function formatValidationErrors(issues: Issues) {
   return issues.map((issue) => ({

--- a/packages/meetup-shared/src/meetupForm.ts
+++ b/packages/meetup-shared/src/meetupForm.ts
@@ -1,6 +1,6 @@
 import { isValid, parse } from 'date-fns';
 import {
-  Output,
+  type Output,
   ValiError,
   minLength,
   object,

--- a/packages/meetup-shared/src/meetupIssueCommentStatus.ts
+++ b/packages/meetup-shared/src/meetupIssueCommentStatus.ts
@@ -1,4 +1,4 @@
-import { Issues } from 'valibot';
+import { type Issues } from 'valibot';
 
 export type Step =
   | { status: 'idle' | 'loading' | 'success' }

--- a/packages/meetup-shared/src/meetupType.ts
+++ b/packages/meetup-shared/src/meetupType.ts
@@ -6,7 +6,7 @@ import {
   transform,
   isoTimestamp,
 } from 'valibot';
-import { MeetupFormField } from './meetupForm';
+import { type MeetupFormField } from './meetupForm';
 
 type MeetupField = Exclude<MeetupFormField, 'time' | 'date'> & { date: Date };
 

--- a/packages/site/src/components/MeetupCard.astro
+++ b/packages/site/src/components/MeetupCard.astro
@@ -1,5 +1,5 @@
 ---
-import { FrontMeetup } from '../get-meetups';
+import { type FrontMeetup } from '../get-meetups';
 
 type Props = { meetup: FrontMeetup };
 const {

--- a/packages/site/src/components/MeetupListItem.astro
+++ b/packages/site/src/components/MeetupListItem.astro
@@ -1,5 +1,5 @@
 ---
-import { FrontMeetup } from '../get-meetups';
+import { type FrontMeetup } from '../get-meetups';
 import { getRandomLogonumber } from '../utils';
 
 type Props = { meetup: FrontMeetup };

--- a/packages/site/src/components/MeetupPageCard.astro
+++ b/packages/site/src/components/MeetupPageCard.astro
@@ -1,5 +1,5 @@
 ---
-import { FrontMeetup } from '../get-meetups';
+import { type FrontMeetup } from '../get-meetups';
 
 type Props = { meetup: FrontMeetup };
 const {

--- a/packages/site/src/layouts/Meetup.astro
+++ b/packages/site/src/layouts/Meetup.astro
@@ -1,7 +1,7 @@
 ---
 import PageLayout from './PageLayout.astro';
 import MeetupPageCard from '../components/MeetupPageCard.astro';
-import { FrontMeetup } from '../get-meetups';
+import { type FrontMeetup } from '../get-meetups';
 
 type Props = { meetup: FrontMeetup };
 const { meetup } = Astro.props;

--- a/packages/site/src/pages/meetups/[...slug].astro
+++ b/packages/site/src/pages/meetups/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { FrontMeetup, getMeetups } from '../../get-meetups';
+import { type FrontMeetup, getMeetups } from '../../get-meetups';
 import Meetup from '../../layouts/Meetup.astro';
 
 export async function getStaticPaths() {

--- a/packages/site/src/pages/rss.xml.ts
+++ b/packages/site/src/pages/rss.xml.ts
@@ -1,4 +1,4 @@
-import rss, { RSSOptions } from '@astrojs/rss';
+import rss, { type RSSOptions } from '@astrojs/rss';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import { getMeetups } from '../get-meetups';
 

--- a/packages/site/src/utils.ts
+++ b/packages/site/src/utils.ts
@@ -1,5 +1,5 @@
-import { MeetupFormValues } from 'meetup-shared';
-import { FrontMeetups } from './get-meetups';
+import { type MeetupFormValues } from 'meetup-shared';
+import { type FrontMeetups } from './get-meetups';
 
 export const formatMeetupData = (meetup: MeetupFormValues) => {
   const formattedMeetup = structuredClone(meetup);

--- a/packages/site/test/index.test.ts
+++ b/packages/site/test/index.test.ts
@@ -1,4 +1,4 @@
-import { Browser, chromium } from 'playwright';
+import { type Browser, chromium } from 'playwright';
 import { afterAll, beforeAll, expect, test } from 'vitest';
 
 let browser: Browser;

--- a/packages/site/test/submit.test.ts
+++ b/packages/site/test/submit.test.ts
@@ -1,4 +1,4 @@
-import { Browser, chromium } from 'playwright';
+import { type Browser, chromium } from 'playwright';
 import { afterAll, beforeAll, expect, test } from 'vitest';
 
 let browser: Browser;

--- a/packages/site/test/utils.test.ts
+++ b/packages/site/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { MeetupFormValues } from 'meetup-shared';
+import { type MeetupFormValues } from 'meetup-shared';
 import {
   formatMeetupData,
   createShortDescription,
@@ -6,7 +6,7 @@ import {
   getRandomLogonumber,
 } from '../src/utils';
 import { expect, test, beforeEach, afterEach, vi } from 'vitest';
-import { FrontMeetups } from '../src/get-meetups';
+import { type FrontMeetups } from '../src/get-meetups';
 
 beforeEach(() => {
   vi.useFakeTimers();


### PR DESCRIPTION
- add `@typescript-eslint/consistent-type-imports` and fix linting errors
- support windows devs eol issues with ` endOfLine: 'auto'` in .prettierrc.json