### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ pnpm-debug.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+.cache


### PR DESCRIPTION
Add `.cache` to `.gitignore`. Without that the pr action executed when a new meetup issue is created commits changes in the `.cache` folder and fails to push changes with "fatal: the remote end hung up unexpectedly".

<details>
  <summary>Full error</summary>

  ```
  /usr/bin/git push --force-with-lease origin new-meetup-28:refs/heads/new-meetup-28
  error: RPC failed; HTTP 408 curl 22 The requested URL returned error: 408
  send-pack: unexpected disconnect while reading sideband packet
  fatal: the remote end hung up unexpectedly
  Everything up-to-date
  Error: The process '/usr/bin/git' failed with exit code 1
  ```
</details>