### PR TITLE
issue parsing fixes & meetup creation flow changes

### DIFF
--- a/packages/actions-new-meetup/src/index.ts
+++ b/packages/actions-new-meetup/src/index.ts
@@ -83,7 +83,7 @@ async function main() {
         join(
           '../../',
           env.MEETUP_FOLDER,
-          `${sanitizedMeetupTitle}-${sanitizedDate}.md`,
+          `${sanitizedMeetupTitle}-${env.ISSUE_NUMBER}-${sanitizedDate}.md`,
         ),
         newMeetupFile,
       )
@@ -101,7 +101,7 @@ async function main() {
       { status: 'loading' },
     ]);
 
-    const newBranchName = `new-meetup-${sanitizedMeetupTitle}-${sanitizedDate}`;
+    const newBranchName = `new-meetup-${env.ISSUE_NUMBER}`;
 
     const pullRequestTitle = `New meetup: ${meetup.title}`;
     const pullRequestBody = getMeetupPullRequestContent(

--- a/packages/actions-new-meetup/src/index.ts
+++ b/packages/actions-new-meetup/src/index.ts
@@ -7,11 +7,11 @@ import {
   getMeetupMarkdownFileContent,
   getMeetupPullRequestContent,
   meetupFormValuesToMeetup,
-  parseMeetupIssueBody,
 } from 'meetup-shared';
 import fs from 'node:fs/promises';
 import { join } from 'node:path';
 import { object, string, transform } from 'valibot';
+import { parseMeetupIssueBody } from './parseMeetupIssueBody';
 
 const envSchema = object({
   MEETUP_FOLDER: string(),

--- a/packages/actions-new-meetup/src/parseMeetupIssueBody.ts
+++ b/packages/actions-new-meetup/src/parseMeetupIssueBody.ts
@@ -1,5 +1,5 @@
+import { meetupFormValuesSchema } from 'meetup-shared';
 import { safeParseAsync } from 'valibot';
-import { meetupFormValuesSchema } from './meetupForm';
 
 export function parseMeetupIssueBody(body: string) {
   const unverifiedMeetupFormValues = {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,6 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.2.0",
+    "date-fns": "4.1.0",
     "meetup-shared": "workspace:*",
     "octokit": "^3.1.0",
     "valibot": "^0.11.1"

--- a/packages/api/src/workerCreateIssue.ts
+++ b/packages/api/src/workerCreateIssue.ts
@@ -1,7 +1,9 @@
-import { getMeetupIssueBody, meetupSchema, type Meetup } from 'meetup-shared';
+import { meetupSchema, type Meetup } from 'meetup-shared';
 import { App } from 'octokit';
 import { safeParseAsync } from 'valibot';
 import { type Env } from './workerEnv';
+import { tz } from '@date-fns/tz';
+import { format } from 'date-fns';
 
 export async function parseCreateIssueReqBody(
   req: Request,
@@ -102,4 +104,53 @@ export async function createIssue(props: {
       errorResponse: new Response(undefined, { status: 500 }),
     };
   }
+}
+
+export function getMeetupIssueBody(meetup: Meetup) {
+  const { date, time } = extractDateAndTime(meetup.date);
+
+  return `
+### Meetup title
+
+${meetup.title}
+
+### Date
+
+${date}
+
+### Time
+
+${time}
+
+### Street address
+
+${meetup.location}
+
+### Maps link for address
+
+${meetup.locationLink}
+
+### Organizer
+
+${meetup.organizer}
+
+### Organizer link
+
+${meetup.organizerLink}
+
+### Signup link for meetup
+
+${meetup.signupLink}
+
+### Description
+
+${meetup.description}`;
+}
+
+const EuropeHelsinki = tz('Europe/Helsinki');
+function extractDateAndTime(date: Date) {
+  return {
+    date: format(date, 'yyyy-MM-dd', { in: EuropeHelsinki }),
+    time: format(date, 'HH:mm', { in: EuropeHelsinki }),
+  };
 }

--- a/packages/api/src/workerCreateIssue.ts
+++ b/packages/api/src/workerCreateIssue.ts
@@ -76,7 +76,7 @@ export async function createIssue(props: {
       owner: props.env.GITHUB_REPO_OWNER,
       repo: props.env.GITHUB_REPO_NAME,
       labels: ['meetup'],
-      title: props.meetup.title,
+      title: 'New meetup: ' + props.meetup.title,
       body: getMeetupIssueBody(props.meetup),
     });
 

--- a/packages/api/src/workerGetMeetupIssueBody.ts
+++ b/packages/api/src/workerGetMeetupIssueBody.ts
@@ -1,0 +1,52 @@
+import { tz } from '@date-fns/tz';
+import { format } from 'date-fns';
+import { type Meetup } from 'meetup-shared';
+
+export function getMeetupIssueBody(meetup: Meetup) {
+  const { date, time } = extractDateAndTime(meetup.date);
+
+  return `
+### Meetup title
+
+${meetup.title}
+
+### Date
+
+${date}
+
+### Time
+
+${time}
+
+### Street address
+
+${meetup.location}
+
+### Maps link for address
+
+${meetup.locationLink}
+
+### Organizer
+
+${meetup.organizer}
+
+### Organizer link
+
+${meetup.organizerLink}
+
+### Signup link for meetup
+
+${meetup.signupLink}
+
+### Description
+
+${meetup.description}`;
+}
+
+const EuropeHelsinki = tz('Europe/Helsinki');
+function extractDateAndTime(date: Date) {
+  return {
+    date: format(date, 'yyyy-MM-dd', { in: EuropeHelsinki }),
+    time: format(date, 'HH:mm', { in: EuropeHelsinki }),
+  };
+}

--- a/packages/meetup-shared/package.json
+++ b/packages/meetup-shared/package.json
@@ -9,7 +9,8 @@
     "dev": "tsc --watch --preserveWatchOutput"
   },
   "dependencies": {
-    "date-fns": "^2.30.0",
+    "@date-fns/tz": "^1.2.0",
+    "date-fns": "^4.1.0",
     "valibot": "^0.11.1"
   }
 }

--- a/packages/meetup-shared/src/meetupIssue.ts
+++ b/packages/meetup-shared/src/meetupIssue.ts
@@ -50,10 +50,14 @@ export function parseMeetupIssueBody(body: string) {
     date: getValueFromBody(body, 'Date'),
     time: getValueFromBody(body, 'Time'),
     location: getValueFromBody(body, 'Street address'),
-    locationLink: getValueFromBody(body, 'Maps link for address'),
+    locationLink: addHttpsIfMissing(
+      getValueFromBody(body, 'Maps link for address'),
+    ),
     organizer: getValueFromBody(body, 'Organizer'),
-    organizerLink: getValueFromBody(body, 'Organizer link'),
-    signupLink: getValueFromBody(body, 'Signup link for meetup'),
+    organizerLink: addHttpsIfMissing(getValueFromBody(body, 'Organizer link')),
+    signupLink: addHttpsIfMissing(
+      getValueFromBody(body, 'Signup link for meetup'),
+    ),
     description: getRestAfterTitle(body, 'Description'),
   };
 
@@ -87,4 +91,11 @@ function getRestAfterTitle(body: string, title: string) {
   }
 
   return null;
+}
+
+function addHttpsIfMissing(url: string | null) {
+  if (url && !url.startsWith('http')) {
+    return `https://${url}`;
+  }
+  return url;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,12 @@ importers:
 
   packages/api:
     dependencies:
+      '@date-fns/tz':
+        specifier: ^1.2.0
+        version: 1.2.0
+      date-fns:
+        specifier: 4.1.0
+        version: 4.1.0
       meetup-shared:
         specifier: workspace:*
         version: link:../meetup-shared
@@ -115,9 +121,12 @@ importers:
 
   packages/meetup-shared:
     dependencies:
+      '@date-fns/tz':
+        specifier: ^1.2.0
+        version: 1.2.0
       date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
+        specifier: ^4.1.0
+        version: 4.1.0
       valibot:
         specifier: ^0.11.1
         version: 0.11.1
@@ -508,11 +517,9 @@ packages:
       '@babel/types': 7.22.10
     dev: false
 
-  /@babel/runtime@7.22.10:
-    resolution: {integrity: sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==}
+  /@babel/runtime@7.27.6:
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.14.0
     dev: false
 
   /@babel/template@7.22.5:
@@ -605,6 +612,10 @@ packages:
   /@cloudflare/workers-types@4.20230419.0:
     resolution: {integrity: sha512-MfNBlHrI/ekRkbLtdAo23D4hkXF+3QD92OCwuXxCUK73HtMHuBqkMp9T/8KFbKNRCnz7PzUderc7Jr5m3eeW3g==}
     dev: true
+
+  /@date-fns/tz@1.2.0:
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
+    dev: false
 
   /@esbuild-kit/cjs-loader@2.4.2:
     resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
@@ -3056,7 +3067,11 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.27.6
+    dev: false
+
+  /date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
     dev: false
 
   /debug@2.6.9:
@@ -6033,10 +6048,6 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
-
-  /regenerator-runtime@0.14.0:
-    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
-    dev: false
 
   /regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}


### PR DESCRIPTION
- add https to links if missing when parsing issue body
- write date and time in Europe/Helsinki tz when creating issue submitted via the web form, since issue parsing expects Europe/Helsinki
  - move issue creating and parsing out of `meetup-shared` closer to where they're used, since the logic is not actually shared. Creating only happens in `api` and parsing only happens in `actions-new-meetup`
  - `@date-fns/tz` was installed in `api` for the timezone changes. This required a newer version of `date-fns`. But other packages in the repo also depend on `date-fns`! Specifically on the earlier version. Updating would require code changes to their usages of `date-fns`. Moving the usages and only updating `date-fns` in `api` enables this to be done later by allowing multiple different versions of `date-fns` in the repo at the same time
  - `api`: `date-fns` 2.30.0 -> 4.1.0
- add issue number to the new meetup file and branch names when creating a pr from issue
- add "New meetup: " prefix to issues created via web form -> worker -> POST github api